### PR TITLE
add oneliner to install dev version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ How to install gatekeeper into a tenant cluster
 ```
 $ GITHUB_TOKEN=<your github token> # created at https://github.com/settings/token
 $ BRANCH=master
-$ helm --tiller-namespace=giantswarm install https://giantswarm.github.io/giantswarm-incubator-test-catalog/gatekeeper-app-0.0.0-$(curl -sSH "Authorization: token $(cat ~/secrets/theo/github.com-token)" https://api.github.com/repos/giantswarm/gatekeeper-app/commits/$BRANCH|jq -r .sha).tgz --name gatekeeper
+$ helm --tiller-namespace=giantswarm install https://giantswarm.github.io/giantswarm-incubator-test-catalog/gatekeeper-app-0.0.0-$(curl -sSH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/giantswarm/gatekeeper-app/commits/$BRANCH|jq -r .sha).tgz --name gatekeeper
 ```
 
 ## Credit


### PR DESCRIPTION
Towards: giantswarm/giantswarm#7648

Add onliner to install gatekeeper to tenant cluster.