### PR TITLE
circleci: bump architect-orb to 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.5.3
+  architect: giantswarm/architect@0.6.0
 
 workflows:
   build-and-push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix internal release process.
+
 ## [0.1.5] - 2020-02-11
 
 ## Added


### PR DESCRIPTION
Includes a fix for pushing new unique app in push-to-app-collection job.

## Checklist

- [x] Update changelog in CHANGELOG.md.
