### PR TITLE
Upgrade to v3.1.0 beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Sync with upstream
+- Update container image to v3.1.0-beta.8
+
 ## [0.2.0] - 2020-03-12
 
 - Update container image to v3.1.0-beta.7

--- a/helm/gatekeeper-app/Chart.yaml
+++ b/helm/gatekeeper-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v3.1.0-beta.7
+appVersion: v3.1.0-beta.8
 description: Chart deploying OPA Gatekeeper.
 icon: https://avatars1.githubusercontent.com/u/16468693?s=400&v=4
 name: gatekeeper-app

--- a/helm/gatekeeper-app/templates/gatekeeper.yaml
+++ b/helm/gatekeeper-app/templates/gatekeeper.yaml
@@ -457,6 +457,8 @@ spec:
       release: '{{ .Release.Name }}'
   template:
     metadata:
+      annotations: 
+{{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
         app: '{{ template "gatekeeper-operator.name" . }}'
         chart: '{{ template "gatekeeper-operator.name" . }}'
@@ -464,16 +466,13 @@ spec:
         gatekeeper.sh/system: "yes"
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
-      {{- if .Values.podAnnotations }}
-      annotations:
-        {{- toYaml .Values.podAnnotations | nindent 8 }}
-      {{- end }}
     spec:
       containers:
       - args:
         - --audit-interval={{ .Values.auditInterval }}
         - --port=8443
         - --logtostderr
+        - --log-level={{ .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
         - --audit-from-cache={{ .Values.auditFromCache }}
         - --exempt-namespace=gatekeeper-system
@@ -514,6 +513,9 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000

--- a/helm/gatekeeper-app/values.yaml
+++ b/helm/gatekeeper-app/values.yaml
@@ -2,13 +2,16 @@ replicas: 1
 auditInterval: 60
 constraintViolationsLimit: 20
 auditFromCache: false
+logLevel: INFO
 image:
   name: giantswarm/gatekeeper
-  release: v3.1.0-beta.7
+  release: v3.1.0-beta.8
   pullPolicy: IfNotPresent
 nodeSelector: {}
 tolerations: []
-podAnnotations: {}
+podAnnotations: {
+  container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+}
 resources:
   limits:
     cpu: 1000m

--- a/patch/01.docker-image.patch
+++ b/patch/01.docker-image.patch
@@ -21,6 +21,6 @@ index e916056..1747f0a 100644
  image:
 -  repository: quay.io/open-policy-agent/gatekeeper
 +  name: giantswarm/gatekeeper
-   release: v3.1.0-beta.7
+   release: v3.1.0-beta.8
    pullPolicy: IfNotPresent
  nodeSelector: {}


### PR DESCRIPTION
This PR updates the helm chart to run [gatekeeper v3.1.0-beta.8](https://github.com/open-policy-agent/gatekeeper/releases/tag/v3.1.0-beta.8) which includes opa 0.17.2

## Checklist

- [x] Update changelog in CHANGELOG.md.
