### PR TITLE
release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2020-04-15
+
 - Fix labels & selectorLabels in chart
 
 ## [0.2.2] - 2020-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add helm charts.
 - Add script to sync upstream changes in the helm chart.
 
-[Unreleased]: https://github.com/giantswarm/gatekeeper-app/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/giantswarm/gatekeeper-app/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/giantswarm/gatekeeper-app/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/giantswarm/gatekeeper-app/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/giantswarm/gatekeeper-app/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/giantswarm/gatekeeper-app/compare/v0.1.6...v0.2.0


### PR DESCRIPTION
Minor release because of changed labels.

Selector labels were not like described in [`fmt`](https://github.com/giantswarm/fmt/blob/master/kubernetes/annotations_and_labels.md#labels-set-on-objects-installed-by-charts) causing the gatekeeper service not matching the pod labels.

Ping @giantswarm/team-magic because they own gatekeeper-app.


## Checklist

- [x] Update changelog in CHANGELOG.md.
