### PR TITLE
remove check-ignore-label.gatekeeper.sh from validatingwebhook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.8.9
+  architect: giantswarm/architect@0.10.0
 
 workflows:
   build-and-push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Removed
+
+- Remove check-ignore-label.gatekeeper.sh from validating webhook
+
 ## [0.3.1] - 2020-05-20
 
 - Moving CRDs into a separate directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
-- Remove check-ignore-label.gatekeeper.sh from validating webhook (#34)
+- Remove check-ignore-label.gatekeeper.sh from validating webhook [#34](https://github.com/giantswarm/gatekeeper-app/pull/34)
 
 ## [0.3.2] - 2020-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Removed
 
-- Remove check-ignore-label.gatekeeper.sh from validating webhook
+- Remove check-ignore-label.gatekeeper.sh from validating webhook (#34)
 
 ## [0.3.2] - 2020-07-03
 

--- a/helm/gatekeeper-app/Chart.yaml
+++ b/helm/gatekeeper-app/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 appVersion: v3.1.0-beta.8
 description: Chart deploying OPA Gatekeeper.
+home: https://github.com/giantswarm/gatekeeper-app
 icon: https://avatars1.githubusercontent.com/u/16468693?s=400&v=4
 name: gatekeeper-app
 version: [[ .Version ]]

--- a/helm/gatekeeper-app/templates/gatekeeper.yaml
+++ b/helm/gatekeeper-app/templates/gatekeeper.yaml
@@ -330,23 +330,3 @@ webhooks:
     - '*'
   sideEffects: None
   timeoutSeconds: 5
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: gatekeeper-webhook-service
-      namespace: gatekeeper-system
-      path: /v1/admitlabel
-  failurePolicy: Fail
-  name: check-ignore-label.gatekeeper.sh
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - namespaces
-  sideEffects: None
-  timeoutSeconds: 5


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11401

This removed the check-ignore-label.gatekeeper.sh rule from the
validatingwebhook which is used by gatekeeper to ensure only given namespaces
(default to gatekeeper-system) can have the admission.gatekeeper.sh/ignore label
and therefore be ignored by gatekeeper.

We should be safe without this because addind the ignore label on a
namespace is a conscious action, therefore we know what we are doing.

This was tested on a tenant cluster:
* deploy gatekeeper withouth the `check-ignore-label.gatekeeper.sh` rule
* ensure it is not running

* apiserver keep throwing lot of error due to gatekeeper not being reachable
* create/delete/update namespaces works

## Checklist

- [x] Update changelog in CHANGELOG.md.