### PR TITLE
Add Prometheus labels/annotations to GK service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Prometheus labels/annotations to GateKeeper service to enable automatic
+  scraping by GS Prometheus [#41](https://github.com/giantswarm/gatekeeper-app/pull/41)
+
 ## [1.0.0] - 2020-07-06
 
 ## Removed

--- a/helm/gatekeeper-app/templates/_helpers.tpl
+++ b/helm/gatekeeper-app/templates/_helpers.tpl
@@ -33,3 +33,24 @@ Selector labels
 app.kubernetes.io/name: {{ include "gatekeeper-operator.name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}
+
+{{/*
+Monitoring selector labels
+
+These enable the service to be monitored by the new Giant Swarm Prometheus
+when applied to a service.
+*/}}
+{{- define "monitoringLabels" -}}
+giantswarm.io/monitoring: "true"
+{{- end -}}
+
+{{/*
+Monitoring configuration annotations
+
+These enable and configure monitoring of the app when applied to a service.
+*/}}
+{{- define "monitoringConfigurationAnnotations" -}}
+prometheus.io/scrape: "true"
+prometheus.io/port: "8888"
+giantswarm.io/monitoring-port: "8888"
+{{- end -}}

--- a/helm/gatekeeper-app/templates/gatekeeper.yaml
+++ b/helm/gatekeeper-app/templates/gatekeeper.yaml
@@ -187,8 +187,11 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    {{- include "monitoringConfigurationAnnotations" . | nindent 4 }}
   labels:
     {{- include "gatekeeper-operator.labels" . | nindent 4 }}
+    {{- include "monitoringLabels" . | nindent 4 }}
     gatekeeper.sh/system: "yes"
   name: gatekeeper-webhook-service
   namespace: gatekeeper-system

--- a/patch/06.monitoring-labels-annotations.patch
+++ b/patch/06.monitoring-labels-annotations.patch
@@ -1,0 +1,54 @@
+commit 39418d8e5d08dd208cd91dd88d7787548d1c0434
+Author: mig4 <42650719@auril.club>
+Date:   Thu Jul 16 00:04:18 2020 +0100
+
+    Add Prometheus labels/annotations to GK service
+    
+    This should allow the service be picked up by the workload scrape job
+    and by `ServiceMonitor` in the new _Prometheus_ setup.
+
+diff --git a/helm/gatekeeper-app/templates/_helpers.tpl b/helm/gatekeeper-app/templates/_helpers.tpl
+index b9fa1e1..7edcaef 100644
+--- a/helm/gatekeeper-app/templates/_helpers.tpl
++++ b/helm/gatekeeper-app/templates/_helpers.tpl
+@@ -33,3 +33,24 @@ Selector labels
+ app.kubernetes.io/name: {{ include "gatekeeper-operator.name" . | quote }}
+ app.kubernetes.io/instance: {{ .Release.Name | quote }}
+ {{- end -}}
++
++{{/*
++Monitoring selector labels
++
++These enable the service to be monitored by the new Giant Swarm Prometheus
++when applied to a service.
++*/}}
++{{- define "monitoringLabels" -}}
++giantswarm.io/monitoring: "true"
++{{- end -}}
++
++{{/*
++Monitoring configuration annotations
++
++These enable and configure monitoring of the app when applied to a service.
++*/}}
++{{- define "monitoringConfigurationAnnotations" -}}
++prometheus.io/scrape: "true"
++prometheus.io/port: "8888"
++giantswarm.io/monitoring-port: "8888"
++{{- end -}}
+diff --git a/helm/gatekeeper-app/templates/gatekeeper.yaml b/helm/gatekeeper-app/templates/gatekeeper.yaml
+index 346ec56..c3386e1 100644
+--- a/helm/gatekeeper-app/templates/gatekeeper.yaml
++++ b/helm/gatekeeper-app/templates/gatekeeper.yaml
+@@ -187,8 +187,11 @@ metadata:
+ apiVersion: v1
+ kind: Service
+ metadata:
++  annotations:
++    {{- include "monitoringConfigurationAnnotations" . | nindent 4 }}
+   labels:
+     {{- include "gatekeeper-operator.labels" . | nindent 4 }}
++    {{- include "monitoringLabels" . | nindent 4 }}
+     gatekeeper.sh/system: "yes"
+   name: gatekeeper-webhook-service
+   namespace: gatekeeper-system


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11232.

This should allow the service be picked up by the workload scrape job
and by `ServiceMonitor` in the new _Prometheus_ setup.

## Checklist

- [x] Update changelog in CHANGELOG.md.
