### PR TITLE
lower validatingwebhook timeout from 5s to 3s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Lower validating webhook timeout from 5s to 3s, which was disrupting leader election [#43](https://github.com/giantswarm/gatekeeper-app/pull/43)
+
 ## [1.1.0] - 2020-08-07
 
 ### Added

--- a/helm/gatekeeper-app/templates/gatekeeper.yaml
+++ b/helm/gatekeeper-app/templates/gatekeeper.yaml
@@ -332,4 +332,4 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
-  timeoutSeconds: 5
+  timeoutSeconds: 3


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11401

When all 3 master nodes are re-created at once, when they come up their respective `kube-scheduler` and `kube-controller-manager` go through leader election.

When gatekeeper is down and the validating webhook is installed, pods keeps "fighting" over leader election and nodes stay in NotReady state. So far the solution was to remove the validating webhook to fix this.

When lowering the validating webhook timeout below 5s, the leader election go through and nodes become Ready

## Checklist

- [x] Update changelog in CHANGELOG.md.